### PR TITLE
[ENH]: Enable CORS for resource sharing

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,5 +1,6 @@
 from main import get_conversation
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import uvicorn
 
@@ -9,6 +10,15 @@ class Query(BaseModel):
     text: str
 
 app = FastAPI()
+
+# Enable CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Allows all origins
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["*"],
+)
 
 @app.get("/")
 def hello():


### PR DESCRIPTION
- fixes #2 
**Add CORS for resource sharing** : This pull request fixes the cross-origin issue and adds the CORS origin for frontend interaction.

When the frontend is ready, we introduce the unique origin in feature demo that is seen below. 

 ```
     origins = [
        "http://localhost",
        "http://localhost:8080",
        "http://example.com"
    ]

    app.add_middleware(
        CORSMiddleware,
        allow_origins=origins,  # Allows specified origins
        allow_credentials=True,
        allow_methods=["GET", "POST", "OPTIONS"], 
        allow_headers=["*"],  
    )
 
 ```


<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) requests for more info.

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.